### PR TITLE
SVCPLAN-2747: configure rsyslog with reopenOnTruncate

### DIFF
--- a/templates/rsyslog.gridftp.conf.epp
+++ b/templates/rsyslog.gridftp.conf.epp
@@ -8,4 +8,5 @@ input(type="imfile"
         Severity="info"
 #       Ruleset="default"
         PersistStateInterval="1000"
+        reopenOnTruncate="on"
         freshStartTail="on")


### PR DESCRIPTION
imfile watching gridftp.log needs to know to reopen the file when it is truncated (which happens during log rotation)