### PR TITLE
Svcplan 8595:  add rsyslog rule for compute agent logs

### DIFF
--- a/manifests/compute_agent/config_mep.pp
+++ b/manifests/compute_agent/config_mep.pp
@@ -219,6 +219,6 @@ input(type="imfile"
   discardTruncatedMsg="on"
   msgDiscardingError="on"
 )
-EOT,
+EOT
   }
 }

--- a/manifests/compute_agent/config_mep.pp
+++ b/manifests/compute_agent/config_mep.pp
@@ -205,6 +205,7 @@ file { 'agentlog-to-rsyslog':
   owner   => 'root',
   group   => 'root',
   mode    => '0644',
+  notify  => Service['rsyslog'],
   content => @(EOT)
 # We need the imfile module
 module(load="imfile" PollingInterval="5")
@@ -218,6 +219,6 @@ input(type="imfile"
   discardTruncatedMsg="on"
   msgDiscardingError="on"
 )
-EOT
+EOT,
   }
 }

--- a/manifests/compute_agent/config_mep.pp
+++ b/manifests/compute_agent/config_mep.pp
@@ -198,15 +198,15 @@ class profile_globus::compute_agent::config_mep {
     source => 'puppet:///modules/profile_globus/mapapp.py',
   }
 
-# Setup an rsyslog rule to get the agent log messages into the log stream
-file { 'agentlog-to-rsyslog':
-  ensure  => file,
-  path    => "/etc/rsyslog.d/60_globus_compute.conf",
-  owner   => 'root',
-  group   => 'root',
-  mode    => '0644',
-  notify  => Service['rsyslog'],
-  content => @("CONTENT")
+  # Setup an rsyslog rule to get the agent log messages into the log stream
+  file { 'agentlog-to-rsyslog':
+    ensure  => file,
+    path    => "/etc/rsyslog.d/60_globus_compute.conf",
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    notify  => Service['rsyslog'],
+    content => @("CONTENT")
     # We need the imfile module
     module(load="imfile" PollingInterval="5")
 
@@ -219,6 +219,6 @@ file { 'agentlog-to-rsyslog':
       discardTruncatedMsg="on"
       msgDiscardingError="on"
     )
-  | CONTENT
+    | CONTENT
   }
 }

--- a/manifests/compute_agent/config_mep.pp
+++ b/manifests/compute_agent/config_mep.pp
@@ -197,4 +197,28 @@ class profile_globus::compute_agent::config_mep {
     owner  => 'root',
     source => 'puppet:///modules/profile_globus/mapapp.py',
   }
+
+# Setup an rsyslog rule to get the agent log messages into the log stream
+file { 'agentlog-to-rsyslog':
+  ensure  => file,
+  path    => "/var/rsyslog.d/60_globus_compute.conf",
+  owner   => 'root',
+  group   => 'root',
+  mode    => '0644',
+  content => @(EOT)
+# We need the imfile module
+module(load="imfile" PollingInterval="5")
+
+# Our endpoint log file
+input(type="imfile"
+  File="/root/.globus_compute/${endpoint_name}/endpoint.log"
+  Tag="GCA:"
+  PersistStateInterval="0"
+  reopenOnTruncate="on"
+  discardTruncatedMsg="on"
+  msgDiscardingError="on"
+)
+EOT
+  }
 }
+

--- a/manifests/compute_agent/config_mep.pp
+++ b/manifests/compute_agent/config_mep.pp
@@ -206,19 +206,19 @@ file { 'agentlog-to-rsyslog':
   group   => 'root',
   mode    => '0644',
   notify  => Service['rsyslog'],
-  content => @(EOT)
-# We need the imfile module
-module(load="imfile" PollingInterval="5")
+  content => @("CONTENT")
+    # We need the imfile module
+    module(load="imfile" PollingInterval="5")
 
-# Our endpoint log file
-input(type="imfile"
-  File="/root/.globus_compute/${endpoint_name}/endpoint.log"
-  Tag="GCA:"
-  PersistStateInterval="0"
-  reopenOnTruncate="on"
-  discardTruncatedMsg="on"
-  msgDiscardingError="on"
-)
-EOT
+    # Our endpoint log file
+    input(type="imfile"
+      File="/root/.globus_compute/${endpoint_name}/endpoint.log"
+      Tag="GCA:"
+      PersistStateInterval="0"
+      reopenOnTruncate="on"
+      discardTruncatedMsg="on"
+      msgDiscardingError="on"
+    )
+  | CONTENT
   }
 }

--- a/manifests/compute_agent/config_mep.pp
+++ b/manifests/compute_agent/config_mep.pp
@@ -201,7 +201,7 @@ class profile_globus::compute_agent::config_mep {
 # Setup an rsyslog rule to get the agent log messages into the log stream
 file { 'agentlog-to-rsyslog':
   ensure  => file,
-  path    => "/var/rsyslog.d/60_globus_compute.conf",
+  path    => "/etc/rsyslog.d/60_globus_compute.conf",
   owner   => 'root',
   group   => 'root',
   mode    => '0644',
@@ -221,4 +221,3 @@ input(type="imfile"
 EOT
   }
 }
-


### PR DESCRIPTION
Added a file resource to config_mep to create an rsyslog rule/file to pull the compute agent log messages from its "local" log file and get them into the rsyslog stream. Agent messages are now included in /var/log messages and get forwarded to the loghost as expected/desired by security. It's likely this could also be managed with journald but rsyslog/imrule was the most expeditious route to close this out.